### PR TITLE
refactor: unify build scripts and merging

### DIFF
--- a/tests/dev-dependencies/tsconfig.json
+++ b/tests/dev-dependencies/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleDetection": "force",
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
-    "preserveSymlinks": true,
     "erasableSyntaxOnly": true,
 
     "strict": true,


### PR DESCRIPTION
Clean up discrepancies between workspace and non-workspace builds. Factor out the concept of a "mergable" by creating an explicit derivation builder for it and reusing that where relevant.