### PR TITLE
fix: don't link but copy node_modules contents

### DIFF
--- a/package-lock2nix.nix
+++ b/package-lock2nix.nix
@@ -16,12 +16,10 @@
 
 # Parse a package.json and package-lock.json into a built derivation.  This
 # module parses the package-lock.json into an eval-time dependency tree to
-# download and install every dependency as individual nix derivations.  It links
-# them all together into one big final symlink forest, meaning anything that
-# uses this folder for its node_modules must run with NODE_PRESERVE_SYMLINKS=1,
-# or equivalent (e.g. tsconfig.json’s compilerOptions.preserveSymlinks=true).
-# It is npm workspace aware and does treeshaking of dependencies when building
-# individual packages for different workspaces.
+# download and install every dependency as individual nix derivations.  It
+# combines them all into one big final node_modules directory, similar to what
+# ‘npm ci’ would do.  It is npm workspace aware and does treeshaking of
+# dependencies when building individual packages for different workspaces.
 #
 # The API is not set in stone: this works for us, for now, it’s quite ad-hoc, we
 # hope to learn about a better API as usage continues.
@@ -171,18 +169,25 @@ let
           ) files
         );
 
-      # Turn an attrset of derivations into a directory containing a symlink to
-      # each.  Also exposes an attribute in passthru, .mergeInto, which is a
-      # script to merge this final directory into an existing directory.  If any
-      # of the contents are themselves also mergeable, this is done recursively.
-      # “Merging” means that if the target doesn’t yet exist, a fresh symlink is
-      # created as usual, but if a directory with that name already exists the
-      # script will merge all its contents into that existing directory.
+      defaultCopyCommand = "cp -r";
+
+      # Turn an attrset of derivations into a directory containing their
+      # realized outputs.  Also exposes an attribute in passthru, .mergeInto,
+      # which is a script to merge this final directory into an existing
+      # directory.  If any of the contents are themselves also mergeable, this
+      # is done recursively.  “Merging” means that if the target doesn’t yet
+      # exist, the derivation is included as usual, but if a directory with that
+      # name already exists the script will merge all its contents into that
+      # existing directory.
       #
-      # This is useful for setting up an initial wireframe of a directory and
-      # then merging a different tree into it.  Think a node_modules with a few
-      # local symlinks, into which the remaining external third party
-      # dependencies are merged.
+      # By default derivations are copied over (see defaultCopyCommand), but
+      # derivations can change how they are included by exposing an attribute
+      # ‘copyCommand’.
+      #
+      # This builder is useful for setting up an initial wireframe of a
+      # directory and then merging a different tree into it.  Think a
+      # node_modules with a few local symlinks, into which the remaining
+      # external third party dependencies are merged.
       mkMergeable = lib.extendMkDerivation {
         constructDrv = stdenvNoCC.mkDerivation;
         excludeDrvArgNames = [
@@ -208,7 +213,7 @@ let
             ''
             + lib.concatLines (
               lib.mapAttrsToList (n: v: ''
-                ln -s ${v} $out/${lib.escapeShellArg n}
+                ${v.copyCommand or defaultCopyCommand} ${v} $out/${lib.escapeShellArg n}
               '') contents
             )
             + ''
@@ -236,7 +241,7 @@ let
                     # If this isn’t a merge-into script then just link it, no
                     # matter what.
                     + ''
-                      ln -s ${v} "$1/"${lib.escapeShellArg n}
+                      ${v.copyCommand or defaultCopyCommand} ${v} "$1/"${lib.escapeShellArg n}
                     ''
                     + lib.optionalString (isMergeable) ''
                       fi
@@ -336,6 +341,19 @@ let
                 scopeSelf.mkNpmModule {
                   src = root + ("/" + p.resolved);
                   npmOverrides = srcOverrides;
+                  # Local dependencies must be linked to prevent double
+                  # inclusion of a local dependency from separate packages.
+                  # E.g. for these local packages depending on each other:
+                  #
+                  # foo -> bar
+                  #   \      \
+                  #    \     v
+                  #     --> quux
+                  #
+                  # If dependencies are copied (or linked, but with
+                  # NODE_PRESERVE_SYMLINKS enabled), quux will be imported twice
+                  # as separate dependencies.  This is generally undesirable.
+                  copyCommand = "ln -s";
                 }
               else
                 mkNodeSingleDep {
@@ -389,81 +407,28 @@ let
                 contents = recursed;
                 name = "node-modules-batch";
                 nativeBuildInputs = [ jq ];
-                # makeRelativeWrapper is a horrible variant of makeWrapper
-                # (without any of the flags) which respects relative paths to
-                # the link, at invocation time.  The resulting binary acts like
-                # a symlink without actually being a symlink.  It doesn’t touch
-                # the working dir, it just finds the target script /relative/ to
-                # the wrapper script and execs into that.  You can’t do a simple
-                # ‘exec ../../my/target.sh’ because those ../.. are interpreted
-                # relative to the working directory of the caller, not the
-                # wrapper script.  And why not a normal symlink?  Because the
-                # node.js ecosystem is in a horrible state of symlink support:
-                # node has two flags, --preserve-symlinks and
-                # --preserve-symlinks-main: the former is for regular
-                # require/import calls in node.js code, the latter is an
-                # entirely separate flag to support preserving symlinks _of the
-                # entrypoint_.  That isn’t default because so many node.js
-                # packages actually _expect_ non-preservation of symlinks for
-                # their entrypoint, because they _expect_ to be symlinked from
-                # node_modules/.bin/foo-pkg -> node_modules/foo-pkg/main.js.  In
-                # main.js they’ll do things like ‘require("./utils.js")’ which
-                # would fail if you actually preserved symlinks (there is no
-                # node_modules/.bin/utils.js).  Even npm and npx themselves
-                # break if you set that flag to true, so you really can’t do it
-                # at derivation level.
-                #
-                # This is all compounded by the obsolesence of NODE_PATH:
-                # node.js really only works reliably if all dependencies are in
-                # <rootDir>/node_modules/*.  If you take the “default” route:
-                #
-                #   - node_modules/.bin/foo-pkg is a symlink -> ../foo-pkg/main.js
-                #   - node_modules/foo-pkg is itself a symlink -> /nix/store/...-foo-pkg/
-                #   - NODE_PRESERVE_SYMLINKS=1
-                #   - NODE_PRESERVE_SYMLINKS_MAIN is unset
-                #
-                # then foo-pkg/main.js will be found, but will be called as
-                # /nix/store/...-foo-pkg/main.js, so it won’t find any sister
-                # dependencies which it declared it needed.  There is only one
-                # reliable way to handle dependencies, it’s not NODE_PATH: when
-                # you call foo-pkg/main.js, node /must/ call it as
-                # <rootDir>/node_modules/foo-pkg/main.js, aka: all symlinks in
-                # the entire chain must be preserved.  That means you must
-                # enable NODE_PRESERVE_SYMLINKS and NODE_PRESERVE_SYMLINKS_MAIN,
-                # but node.js must be aware (somehow) that the entrypoint script
-                # is called from <rootDir>/node_modules/foo-pkg/main.js instead
-                # of <rootDir>/node_modules/.bin/foo-pkg: that is achieved by
-                # this insane wrapper.
-                #
-                # - https://github.com/nodejs/node/issues/19383
-                #
-                # 😰
                 postInstall = ''
-
-                  makeRelativeWrapper() {
-                    set -eu
-                    >"$2" cat <<EOF
-                  #!$shell
-                  set -eu
-                  export NODE_PRESERVE_SYMLINKS_MAIN=1
-                  d="\$(dirname "\''${BASH_SOURCE[0]}")"
-                  exec "\$d/$1" "\$@"
-                  EOF
-                    chmod +x "$2"
-                  }
                   (
                     cd $out
                     set -eu
                     shopt -s nullglob
                     for d in */ @*/*/ ; do
-                      if [[ -f "$d"package.json ]]; then
-                        <"$d/package.json" jq -r '.name as $name | (.bin // empty) | if type == "object" then . else {"\($name)": .} end| to_entries | .[]| [.key, .value] | @tsv' | while read -r binname path; do
+                      pjson="$d"package.json
+                      if [[ -f "$pjson" ]]; then
+                        <"$pjson" jq -r '.name as $name | (.bin // empty) | if type == "object" then . else {"\($name)": .} end| to_entries | .[]| [.key, .value] | @tsv' | while read -r binname path; do
                           mkdir -p .bin
                           (
                             cd .bin
-                            target="../''${d}$path"
+                            target="../$d""$path"
                             src="''${binname##*/}"
-                            makeRelativeWrapper "$target" "$src"
+                            # As far as I can tell npm behavior is to blindly
+                            # override binaries with conflicting binary names.
+                            # At least warn the user in case they need to debug
+                            # this.  God be with ye.
+                            if [[ -f "$src" ]]; then
+                              >&2 echo "Overwriting existing .bin/$src from $(readlink "$src") to $target"
+                            fi
+                            ln -s -f "$target" "$src"
                           )
                         done
                       fi
@@ -905,7 +870,6 @@ let
                 # DO WHAT YOU CAN TO AVOID USING THIS!  It is a massive crutch.
                 unsymlinkify
               ];
-              NODE_PRESERVE_SYMLINKS = 1;
               # npm will ensure the final binaries are executable for you, though at a
               # weird moment: not when you build the original package, but when someone
               # ultimately installs it.  That causes these files to get symlinked into
@@ -956,38 +920,9 @@ let
 
               fixupNpmBinaries =
                 let
-                  # Reverse hack: _if_ your package depends on npm and/or npx at
-                  # runtime (some packages do this e.g. for version checks) then it
-                  # would break from within a package-lock2nix built derivation,
-                  # because npm and npx are not compatible with
-                  # NODE_PRESERVE_SYMLINKS_MAIN=1.  This pass detects whether there
-                  # is a nodejs derivation in your buildinputs, and before putting
-                  # it on the baked PATH of any dependent binary it inserts a
-                  # wrapped version of npm and npx which does nothing but disable
-                  # that envvar.
-                  symlinkSafeNpmNpx =
-                    nodejs:
-                    stdenvNoCC.mkDerivation {
-                      inherit (nodejs) version;
-                      pname = "npm-npx";
-                      dontUnpack = true;
-                      nativeBuildInputs = [ makeWrapper ];
-                      installPhase = ''
-                        mkdir -p $out/bin
-                        cd "${lib.getBin nodejs}/bin"
-                        for f in npm npx; do
-                          makeWrapper "${lib.getBin nodejs}/bin/$f" "$out/bin/$f" \
-                            --unset NODE_PRESERVE_SYMLINKS_MAIN
-                        done
-                      '';
-                    };
-                  isNodeJs = drv: (drv.pname or "") == "nodejs";
-                  buildInputs' = lib.concatMap (
-                    drv: lib.optionals (isNodeJs drv) [ (symlinkSafeNpmNpx drv) ] ++ [ drv ]
-                  ) (self.buildInputs or [ ]);
                   PATH = lib.concatStringsSep ":" ([
                     "$out/node_modules/.bin"
-                    (lib.makeBinPath buildInputs')
+                    (lib.makeBinPath (self.buildInputs or [ ]))
                   ]);
                   script = lib.concatStringsSep "\n" (
                     lib.mapAttrsToList (
@@ -1002,8 +937,7 @@ let
                           chmod +x $out/${val'}
                           patchShebangs $out/${val'}
                           makeWrapper $out/${val'} $out/bin/${name'} \
-                            --prefix PATH : ${PATH} \
-                            --set-default NODE_PRESERVE_SYMLINKS 1
+                            --prefix PATH : ${PATH}
                         fi
                       ''
                     ) self.passthru.outBins

--- a/tests/dev-dependencies/tsconfig.json
+++ b/tests/dev-dependencies/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleDetection": "force",
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
-    "preserveSymlinks": true,
     "erasableSyntaxOnly": true,
 
     "strict": true,

--- a/tests/local-dep-only/foo.js
+++ b/tests/local-dep-only/foo.js
@@ -1,0 +1,3 @@
+// Re-export the imported foo
+
+export { foo } from "single-no-deps/foo";

--- a/tests/local-nested-deps/foo.test.js
+++ b/tests/local-nested-deps/foo.test.js
@@ -1,0 +1,11 @@
+import { suite, test } from "node:test";
+import { strictEqual } from "node:assert/strict";
+
+import { foo as foo1 } from "single-no-deps/foo";
+import { foo as foo2 } from "local-dep-only/foo";
+
+await suite(import.meta.filename, async () => {
+  await test("nested import equality", async () => {
+    strictEqual(foo1, foo2);
+  });
+});

--- a/tests/local-nested-deps/index.js
+++ b/tests/local-nested-deps/index.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { foo } from "single-no-deps/foo";
+
+function main() {
+  console.log(`hello from local dependency: ${foo()}`);
+}
+
+main();

--- a/tests/local-nested-deps/package-lock.json
+++ b/tests/local-nested-deps/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "local-nested-deps",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "local-nested-deps",
+      "dependencies": {
+        "local-dep-only": "file:../local-dep-only",
+        "single-no-deps": "file:../single-no-deps"
+      }
+    },
+    "../local-dep-only": {
+      "dependencies": {
+        "single-no-deps": "file:../single-no-deps"
+      }
+    },
+    "../single-no-deps": {
+      "bin": {
+        "single-no-deps": "index.js"
+      }
+    },
+    "node_modules/local-dep-only": {
+      "resolved": "../local-dep-only",
+      "link": true
+    },
+    "node_modules/single-no-deps": {
+      "resolved": "../single-no-deps",
+      "link": true
+    }
+  }
+}

--- a/tests/local-nested-deps/package.json
+++ b/tests/local-nested-deps/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "local-dep-only",
+  "name": "local-nested-deps",
   "type": "module",
   "scripts": {
     "build": "echo nothing to build",
-    "test": "echo nothing to test"
+    "test": "node --test"
   },
   "dependencies": {
+    "local-dep-only": "file:../local-dep-only",
     "single-no-deps": "file:../single-no-deps"
   },
   "exports": {

--- a/tests/local-nested-deps/package.nix
+++ b/tests/local-nested-deps/package.nix
@@ -1,0 +1,3 @@
+{ package-lock2nix }:
+
+package-lock2nix.mkNpmModule { src = ./.; }


### PR DESCRIPTION
The experiment has finally run its course. As painful as it is to admit, node just really _does not like symlinks_ and it fights you all the way. The nail in the coffin was transitive linked local dependencies. See comments.